### PR TITLE
main attribute in bower.json sets entry-point file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "whatsapp-sharing",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "homepage": "https://github.com/kriskbx/whatsapp-sharing",
   "authors": [
     "kriskbx"
   ],
-  "main": "whatsapp sharing button generator",
+  "main": "dist/whatsapp-button.js",
   "keywords": [
     "whatsapp",
     "sharing",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-sharing",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "WhatsApp Sharing Button",
   "main": "-",
   "scripts": {


### PR DESCRIPTION
main attribute in bower.json should set entry-point file for package. See bower.json specification:
https://github.com/bower/bower.json-spec

This is important as some tools use it, for example to automatically inject files.