### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * With Git: `git clone https://github.com/kriskbx/whatsapp-sharing.git`
 * Manually: [https://github.com/kriskbx/whatsapp-sharing/releases](https://github.com/kriskbx/whatsapp-sharing/releases) 
 
-Or include the hosted version on [jsdelivr](http://www.jsdelivr.com/): `//cdn.jsdelivr.net/whatsapp-sharing/1.3.3/whatsapp-button.js`
+Or include the hosted version on [jsdelivr](http://www.jsdelivr.com/): `//cdn.jsdelivr.net/npm/whatsapp-sharing@1.3.4/dist/whatsapp-button.js`
 
 ### 2. Integrate the buttons source
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-sharing",
   "version": "1.3.3",
   "description": "WhatsApp Sharing Button",
-  "main": "-",
+  "main": "dist/whatsapp-button.js",
   "scripts": {
     "test": "grunt jshint:button"
   },


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/whatsapp-sharing.

I also set the default file to `dist/whatsapp-sharing.js`.

Feel free to ping me if you have any questions regarding this change.